### PR TITLE
Add PhoneNumberParserFactory

### DIFF
--- a/src/PhoneNumbers/CountryInfo.cs
+++ b/src/PhoneNumbers/CountryInfo.cs
@@ -27,7 +27,7 @@ namespace PhoneNumbers
         public static CountryInfo UK { get; } = new CountryInfo
         {
             CallingCode = "+44",
-            Formatter = new UKPhoneNumberFormatter(),
+            Formatter = new GBPhoneNumberFormatter(),
             InternationalCallPrefix = "00",
             Iso3116Code = "GB",
             NsnLengths = new ReadOnlyCollection<int>(new[] { 7, 9, 10 }),

--- a/src/PhoneNumbers/Formatters/GBPhoneNumberFormatter.cs
+++ b/src/PhoneNumbers/Formatters/GBPhoneNumberFormatter.cs
@@ -4,7 +4,7 @@ namespace PhoneNumbers.Formatters
     /// A <see cref="PhoneNumberFormatter"/> for UK phone numbers.
     /// </summary>
     /// <remarks>See https://www.area-codes.org.uk/formatting.php for the rules this class implements.</remarks>
-    internal sealed class UKPhoneNumberFormatter : PhoneNumberFormatter
+    internal sealed class GBPhoneNumberFormatter : PhoneNumberFormatter
     {
         /// <inheritdoc/>
         protected override string FormatDisplay(PhoneNumber phoneNumber)

--- a/src/PhoneNumbers/ParseOptions.cs
+++ b/src/PhoneNumbers/ParseOptions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using PhoneNumbers.Parsers;
 
 namespace PhoneNumbers
@@ -8,17 +10,25 @@ namespace PhoneNumbers
     /// </summary>
     internal sealed class ParseOptions
     {
+        private readonly PhoneNumberParserFactory _factory = new();
+
         /// <summary>
         /// Gets the default parse options.
         /// </summary>
         internal static ParseOptions Default { get; } = new();
 
         /// <summary>
-        /// Gets the <see cref="PhoneNumberParser"/>s.
+        /// Gets the list of supported <see cref="CountryInfo"/>s.
         /// </summary>
-        internal IList<PhoneNumberParser> Parsers { get; } = new List<PhoneNumberParser>
-        {
-            UKPhoneNumberParser.Create(),
-        };
+        /// <remarks>By default, this will contain all <see cref="CountryInfo"/> static properties.</remarks>
+        internal IList<CountryInfo> Countries { get; } = typeof(CountryInfo)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(x => x.PropertyType == typeof(CountryInfo))
+            .Select(x => x.GetValue(null))
+            .Cast<CountryInfo>()
+            .ToList();
+
+        internal PhoneNumberParser GetParser(CountryInfo countryInfo) =>
+            _factory.GetParser(countryInfo);
     }
 }

--- a/src/PhoneNumbers/Parsers/GBPhoneNumberParser.cs
+++ b/src/PhoneNumbers/Parsers/GBPhoneNumberParser.cs
@@ -12,14 +12,14 @@ namespace PhoneNumbers.Parsers
     /// https://en.wikipedia.org/wiki/List_of_dialling_codes_in_the_United_Kingdom
     /// https://www.area-codes.org.uk/full-uk-area-code-list.php
     /// </remarks>
-    internal sealed class UKPhoneNumberParser : PhoneNumberParser
+    internal sealed class GBPhoneNumberParser : PhoneNumberParser
     {
         private readonly IReadOnlyList<AreaCodeInfo> _areaCodesWith5Digits;
         private readonly IReadOnlyList<AreaCodeInfo> _geographicAreaCodeInfos;
         private readonly IReadOnlyList<AreaCodeInfo> _mobileAreaCodInfos;
         private readonly IReadOnlyList<AreaCodeInfo> _nonGeographicAreaCodeInfos;
 
-        private UKPhoneNumberParser(
+        private GBPhoneNumberParser(
             IReadOnlyList<AreaCodeInfo> geographicAreaCodes,
             IReadOnlyList<AreaCodeInfo> nonGeographicAreaCodes,
             IReadOnlyList<AreaCodeInfo> mobileAreaCodes)
@@ -31,7 +31,7 @@ namespace PhoneNumbers.Parsers
         }
 
         /// <summary>
-        /// Creates an instance of the <see cref="UKPhoneNumberParser"/> class.
+        /// Creates an instance of the <see cref="GBPhoneNumberParser"/> class.
         /// </summary>
         /// <returns>The created <see cref="PhoneNumberParser"/>.</returns>
         internal static PhoneNumberParser Create()
@@ -63,7 +63,7 @@ namespace PhoneNumbers.Parsers
                 }
             }
 
-            return new UKPhoneNumberParser(geographicAreaCodes, nonGeographicAreaCodes, mobileAreaCodes);
+            return new GBPhoneNumberParser(geographicAreaCodes, nonGeographicAreaCodes, mobileAreaCodes);
         }
 
         /// <inheritdoc/>

--- a/src/PhoneNumbers/Parsers/PhoneNumberParserFactory.cs
+++ b/src/PhoneNumbers/Parsers/PhoneNumberParserFactory.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace PhoneNumbers.Parsers
+{
+    internal sealed class PhoneNumberParserFactory
+    {
+        private readonly ConcurrentDictionary<CountryInfo, PhoneNumberParser> _parserCache = new();
+
+        internal PhoneNumberParser GetParser(CountryInfo countryInfo) =>
+            _parserCache.GetOrAdd(
+                countryInfo,
+                x =>
+                {
+                    var createMethod = typeof(PhoneNumberParser)
+                        .Assembly
+                        .GetType($"PhoneNumbers.Parsers.{x.Iso3116Code}PhoneNumberParser")?
+                        .GetMethod("Create", BindingFlags.NonPublic | BindingFlags.Static);
+
+                    if (createMethod?.Invoke(null, null) is PhoneNumberParser parser)
+                    {
+                        return parser;
+                    }
+
+                    throw new NotSupportedException(x.Iso3116Code);
+                });
+    }
+}

--- a/src/PhoneNumbers/PhoneNumber.cs
+++ b/src/PhoneNumbers/PhoneNumber.cs
@@ -104,13 +104,14 @@ namespace PhoneNumbers
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var parser = options.Parsers.SingleOrDefault(x => x.Country.IsInternationalNumber(value));
+            var country = options.Countries.SingleOrDefault(x => x.IsInternationalNumber(value));
 
-            if (parser == null)
+            if (country == null)
             {
                 throw new ParseException("Parse(value) only supports a value starting with a supported calling code, otherwise Parse(value, countryCode) must be used.");
             }
 
+            var parser = options.GetParser(country);
             var result = parser.Parse(value);
             result.ThrowIfFailure();
 
@@ -131,13 +132,14 @@ namespace PhoneNumbers
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var parser = options.Parsers.SingleOrDefault(x => x.Country.Iso3116Code == countryCode);
+            var country = options.Countries.SingleOrDefault(x => x.Iso3116Code == countryCode);
 
-            if (parser == null)
+            if (country == null)
             {
                 throw new ParseException($"{countryCode} is not currently supported.");
             }
 
+            var parser = options.GetParser(country);
             var result = parser.Parse(value);
             result.ThrowIfFailure();
 
@@ -153,10 +155,11 @@ namespace PhoneNumbers
         /// <returns><c>true</c> if value was converted successfully; otherwise, <c>false</c>.</returns>
         internal static bool TryParse(string value, ParseOptions options, out PhoneNumber? phoneNumber)
         {
-            var parser = options?.Parsers.SingleOrDefault(x => x.Country.IsInternationalNumber(value));
+            var country = options?.Countries.SingleOrDefault(x => x.IsInternationalNumber(value));
 
-            if (parser != null)
+            if (country != null)
             {
+                var parser = options!.GetParser(country);
                 var result = parser.Parse(value);
 
                 if (result.PhoneNumber != null)
@@ -180,10 +183,11 @@ namespace PhoneNumbers
         /// <returns><c>true</c> if value was converted successfully; otherwise, <c>false</c>.</returns>
         internal static bool TryParse(string value, string countryCode, ParseOptions options, out PhoneNumber? phoneNumber)
         {
-            var parser = options?.Parsers.SingleOrDefault(x => x.Country.Iso3116Code == countryCode);
+            var country = options?.Countries.SingleOrDefault(x => x.Iso3116Code == countryCode);
 
-            if (parser != null)
+            if (country != null)
             {
+                var parser = options!.GetParser(country);
                 var result = parser.Parse(value);
 
                 if (result.PhoneNumber != null)

--- a/test/PhoneNumbers.Tests/CountryInfo_UK_Tests.cs
+++ b/test/PhoneNumbers.Tests/CountryInfo_UK_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace PhoneNumbers.Tests
 {
-    public class CountryInfoUKTests
+    public class CountryInfo_UK_Tests
     {
         [Fact]
         public void UK()
@@ -13,7 +13,7 @@ namespace PhoneNumbers.Tests
             var countryInfo = CountryInfo.UK;
 
             Assert.Equal("+44", countryInfo.CallingCode);
-            Assert.IsType<UKPhoneNumberFormatter>(countryInfo.Formatter);
+            Assert.IsType<GBPhoneNumberFormatter>(countryInfo.Formatter);
             Assert.Equal("00", countryInfo.InternationalCallPrefix);
             Assert.Equal("GB", countryInfo.Iso3116Code);
             Assert.Equal(new[] { 7, 9, 10 }, countryInfo.NsnLengths);

--- a/test/PhoneNumbers.Tests/Formatters/GBPhoneNumberFormatterTests.cs
+++ b/test/PhoneNumbers.Tests/Formatters/GBPhoneNumberFormatterTests.cs
@@ -5,14 +5,11 @@ using Xunit;
 namespace PhoneNumbers.Tests.Formatters
 {
     /// <summary>
-    /// Contains unit tests for the <see cref="UKPhoneNumberFormatter"/> class.
+    /// Contains unit tests for the <see cref="GBPhoneNumberFormatter"/> class.
     /// </summary>
-    /// <remarks>
-    /// All valid number tests use the local council number for the area code.
-    /// </remarks>
-    public class UKPhoneNumberFormatterTests
+    public class GBPhoneNumberFormatterTests
     {
-        private readonly PhoneNumberFormatter _formatter = new UKPhoneNumberFormatter();
+        private readonly PhoneNumberFormatter _formatter = new GBPhoneNumberFormatter();
 
         [Theory]
         [InlineData("01132224444", "0113 222 4444")] // 11X

--- a/test/PhoneNumbers.Tests/ParseOptionsTests.cs
+++ b/test/PhoneNumbers.Tests/ParseOptionsTests.cs
@@ -1,4 +1,5 @@
-using PhoneNumbers.Parsers;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace PhoneNumbers.Tests
@@ -10,8 +11,14 @@ namespace PhoneNumbers.Tests
         {
             Assert.NotNull(ParseOptions.Default);
 
-            Assert.Single(ParseOptions.Default.Parsers);
-            Assert.Contains(ParseOptions.Default.Parsers, x => x.GetType() == typeof(UKPhoneNumberParser));
+            var countryInfos = typeof(CountryInfo)
+                .GetProperties(BindingFlags.Public | BindingFlags.Static)
+                .Where(x => x.PropertyType == typeof(CountryInfo))
+                .Select(x => x.GetValue(null))
+                .Cast<CountryInfo>()
+                .ToList();
+
+            Assert.Equal(countryInfos, ParseOptions.Default.Countries);
         }
     }
 }

--- a/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests.cs
+++ b/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 namespace PhoneNumbers.Tests.Parsers
 {
     /// <summary>
-    /// Contains unit tests for the <see cref="UKPhoneNumberParser"/> class.
+    /// Contains unit tests for the <see cref="GBPhoneNumberParser"/> class.
     /// </summary>
-    public class UKPhoneNumberParserTests
+    public class GBPhoneNumberParserTests
     {
-        private readonly PhoneNumberParser _parser = UKPhoneNumberParser.Create();
+        private readonly PhoneNumberParser _parser = GBPhoneNumberParser.Create();
 
         [Fact]
         public void Parse_Returns_Failure_For_1XX_AreaCode_And_Local_Number_Not_7_Digits()

--- a/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_GeographicPhoneNumber.cs
+++ b/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_GeographicPhoneNumber.cs
@@ -4,9 +4,9 @@ using Xunit;
 namespace PhoneNumbers.Tests.Parsers
 {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("PhoneNumbers.Utils.TestCaseGen", "2021.01.02")]
-    public class UKPhoneNumberParserTests_GeographicPhoneNumberPhoneNumberParserTests
+    public class GBPhoneNumberParserTests_GeographicPhoneNumberPhoneNumberParserTests
     {
-        private readonly PhoneNumberParser _parser = UKPhoneNumberParser.Create();
+        private readonly PhoneNumberParser _parser = GBPhoneNumberParser.Create();
 
         [Theory]
         [InlineData("01132000000", "113", "2000000", "Leeds")]

--- a/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_MobilePhoneNumber.cs
+++ b/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_MobilePhoneNumber.cs
@@ -4,9 +4,9 @@ using Xunit;
 namespace PhoneNumbers.Tests.Parsers
 {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("PhoneNumbers.Utils.TestCaseGen", "2020.12.31")]
-    public class UKPhoneNumberParserTests_MobilePhoneNumberPhoneNumberParserTests
+    public class GBPhoneNumberParserTests_MobilePhoneNumberPhoneNumberParserTests
     {
-        private readonly PhoneNumberParser _parser = UKPhoneNumberParser.Create();
+        private readonly PhoneNumberParser _parser = GBPhoneNumberParser.Create();
 
         [Theory]
         [InlineData("07106000000", "7106", "000000")]

--- a/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_NonGeographicPhoneNumber.cs
+++ b/test/PhoneNumbers.Tests/Parsers/GBPhoneNumberParserTests_NonGeographicPhoneNumber.cs
@@ -4,9 +4,9 @@ using Xunit;
 namespace PhoneNumbers.Tests.Parsers
 {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("PhoneNumbers.Utils.TestCaseGen", "2020.12.31")]
-    public class UKPhoneNumberParserTests_NonGeographicPhoneNumberPhoneNumberParserTests
+    public class GBPhoneNumberParserTests_NonGeographicPhoneNumberPhoneNumberParserTests
     {
-        private readonly PhoneNumberParser _parser = UKPhoneNumberParser.Create();
+        private readonly PhoneNumberParser _parser = GBPhoneNumberParser.Create();
 
         [Theory]
         [InlineData("03000000000", "300", "0000000")]

--- a/test/PhoneNumbers.Tests/Parsers/PhoneNumberParserFactoryTests.cs
+++ b/test/PhoneNumbers.Tests/Parsers/PhoneNumberParserFactoryTests.cs
@@ -1,0 +1,21 @@
+using PhoneNumbers.Parsers;
+using Xunit;
+
+namespace PhoneNumbers.Tests.Parsers
+{
+    /// <summary>
+    /// Contains unit tests for the <see cref="PhoneNumberParserFactory"/> class.
+    /// </summary>
+    public class PhoneNumberParserFactoryTests
+    {
+        private readonly PhoneNumberParserFactory _factory = new();
+
+        [Fact]
+        public void GetParser_Returns_GBPhoneNumberParser_For_CountryInfo_UK() =>
+            Assert.IsType<GBPhoneNumberParser>(_factory.GetParser(CountryInfo.UK));
+
+        [Fact]
+        public void GetParser_Returns_Same_Instance() =>
+            Assert.Same(_factory.GetParser(CountryInfo.UK), _factory.GetParser(CountryInfo.UK));
+    }
+}

--- a/test/PhoneNumbers.Tests/Parsers/PhoneNumberParserTests.cs
+++ b/test/PhoneNumbers.Tests/Parsers/PhoneNumberParserTests.cs
@@ -7,9 +7,6 @@ namespace PhoneNumbers.Tests.Parsers
     /// <summary>
     /// Contains unit tests for the <see cref="PhoneNumberParser"/> class.
     /// </summary>
-    /// <remarks>
-    /// All tests use unused calling codes and fake numbers.
-    /// </remarks>
     public class PhoneNumberParserTests
     {
         [Fact]


### PR DESCRIPTION
As a convention, use the ISO code as the type name for formatters and parsers, this allows a reflection based parser factory.